### PR TITLE
Updated mydeallocate

### DIFF
--- a/my_malloc.c
+++ b/my_malloc.c
@@ -339,6 +339,10 @@ void mydeallocate(int thread_id, void* ptr)
     loadPage(thread_id, reverseLookup(ptr));
     ptr_header* temp = (ptr_header*)ptr - 1;
     temp->free = 1;
+    if (temp == startingAddressOfPages + page_size*reverseLookup(ptr))
+    {
+        &((page_header*)memory_resource)[reverseLookup(ptr)] -> is_allocated = 0;
+    }
 }
 
 void protect_pages(int thread_id)


### PR DESCRIPTION
mydeallocate might require us to change the is_allocated flag to 0 if the ptr_header is at the start of the page.